### PR TITLE
Update language-pact.cson

### DIFF
--- a/settings/language-pact.cson
+++ b/settings/language-pact.cson
@@ -4,3 +4,15 @@
     'commentStart': '; '
   'autocomplete':
     'extraWordCharacters': '-'
+  'bracket-matcher':
+    autocompleteCharacters: [
+      '()'
+      '[]'
+      '{}'
+      '""'
+      '``'
+      '“”'
+      '‘’'
+      '«»'
+      '‹›'
+    ]


### PR DESCRIPTION
don't show a "matching" quote for single quote strings